### PR TITLE
Realign UCO Perdurant outside of gufo:Event

### DIFF
--- a/ontology/uco-gufo.ttl
+++ b/ontology/uco-gufo.ttl
@@ -83,9 +83,15 @@ drafting:GeneralFacetType
 drafting:Instant
 	a owl:Class ;
 	rdfs:subClassOf
-		drafting:Perdurant ,
+		drafting:InstantaneousPerdurant ,
 		time:Instant
 		;
+	.
+
+drafting:InstantaneousPerdurant
+	a owl:Class ;
+	rdfs:subClassOf drafting:Perdurant ;
+	rdfs:isDefinedBy <https://github.com/ucoProject/UCO/issues/651> ;
 	.
 
 drafting:Perdurant

--- a/ontology/uco-gufo.ttl
+++ b/ontology/uco-gufo.ttl
@@ -6,6 +6,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix time: <http://www.w3.org/2006/time#> .
 @prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix uco-analysis: <https://ontology.unifiedcyberontology.org/uco/analysis/> .
 @prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
@@ -47,6 +48,7 @@ drafting:Endurant
 		uco-core:UcoThing
 		;
 	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/544> ;
+	owl:disjointWith drafting:Perdurant ;
 	.
 
 drafting:FacetType
@@ -78,13 +80,22 @@ drafting:GeneralFacetType
 		;
 	.
 
-drafting:Perdurant
+drafting:Instant
 	a owl:Class ;
 	rdfs:subClassOf
-		gufo:Event ,
-		uco-core:UcoObject
+		drafting:Perdurant ,
+		time:Instant
 		;
-	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/544> ;
+	.
+
+drafting:Perdurant
+	a owl:Class ;
+	rdfs:subClassOf uco-core:UcoObject ;
+	rdfs:seeAlso
+		<https://github.com/ucoProject/UCO/issues/544> ,
+		<https://github.com/ucoProject/UCO/issues/651>
+		;
+	owl:disjointWith drafting:Endurant ;
 	.
 
 drafting:Quality
@@ -162,7 +173,10 @@ drafting:isBearerOf
 	.
 
 uco-action:Action
-	rdfs:subClassOf drafting:Perdurant ;
+	rdfs:subClassOf
+		drafting:Perdurant ,
+		gufo:Event
+		;
 	.
 
 uco-action:endTime
@@ -222,7 +236,10 @@ uco-core:Assertion
 	.
 
 uco-core:Event
-	rdfs:subClassOf drafting:Perdurant ;
+	rdfs:subClassOf
+		drafting:Perdurant ,
+		gufo:Event
+		;
 	.
 
 uco-core:Facet
@@ -334,6 +351,24 @@ uco-types:Hash
 
 []
 	a owl:Axiom ;
+	rdfs:comment "This axiom will be redundant upon resolution of UCO Issue 651."@en ;
+	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/651> ;
+	owl:annotatedObject drafting:Perdurant ;
+	owl:annotatedProperty rdfs:subClassOf ;
+	owl:annotatedSubject uco-action:Action ;
+	.
+
+[]
+	a owl:Axiom ;
+	rdfs:comment "This axiom will be redundant upon resolution of UCO Issue 651."@en ;
+	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/651> ;
+	owl:annotatedObject drafting:Perdurant ;
+	owl:annotatedProperty rdfs:subClassOf ;
+	owl:annotatedSubject uco-core:Event ;
+	.
+
+[]
+	a owl:Axiom ;
 	rdfs:comment
 		"This specialization stems from a Facet currently being understood to be an intrinsic mode that is not measurable.  Were it measurable, a Facet would be a Quality."@en ,
 		"This specialization will raise some disussion pertaining to core:ConfidenceFacet.  If a ConfidenceFacet is measurable, then it is a specialization of gufo:Quality, and Facet should instead be a subclass of IntrinsicAspect."@en
@@ -387,5 +422,13 @@ uco-types:Hash
 	owl:assertionProperty rdfs:subClassOf ;
 	owl:sourceInvididual uco-core:Relationship ;
 	owl:targetInvididual gufo:Relator ;
+	.
+
+[]
+	a owl:NegativePropertyAssertion ;
+	rdfs:comment "This might apply for a more general 'Perdurant' class, but drafting:Perdurant would not be appropriate - it is in the UcoThing subclass hierarchy."@en ;
+	owl:assertionProperty rdfs:subClassOf ;
+	owl:sourceInvididual gufo:Event ;
+	owl:targetInvididual drafting:Perdurant ;
 	.
 

--- a/tests/exemplars.ttl
+++ b/tests/exemplars.ttl
@@ -142,6 +142,10 @@ kb:Instant-2918592a-9d87-4b30-acbc-521a19f97fcd
 	time:inXSDDateTimeStamp "2023-11-22T15:30:00Z"^^xsd:dateTimeStamp ;
 	.
 
+kb:Instant-9c8a3c04-11ee-46a7-b320-8c5abe28b5cc
+	a drafting:Instant ;
+	.
+
 kb:Instant-c9ae3fce-ddcb-416b-971b-559c2f5bee95
 	a time:Instant ;
 	.


### PR DESCRIPTION
It seems "Perdurant" could be a class that may encompass both concrete individuals (gUFO Events) and abstract individuals (OWL-Time Instants, and perhaps other OWL-Time Temporal Entities).